### PR TITLE
Replace xwiki-labs by cryptpad

### DIFF
--- a/FAQ.rst
+++ b/FAQ.rst
@@ -25,7 +25,7 @@ List of extensions known to cause issues with CryptPad
 * Arkenfox (some configurations)
 
 .. note::
-    If you identify issues with another extension please `report it to the development team <https://github.com/xwiki-labs/cryptpad/issues/new/choose>`_
+    If you identify issues with another extension please `report it to the development team <https://github.com/cryptpad/cryptpad/issues/new/choose>`_
 
 I forgot my password
 --------------------
@@ -105,7 +105,7 @@ The development team is considering removing this distinction in future. In the 
 Can I use CryptPad on mobile?
 -----------------------------
 
-CryptPad is engineered to work as well as possible on small screens. Depending on your device performance it should be possible to use CryptPad on mobile. Work to make CryptPad more responsive was undertaken in 2020, if you notice areas that need improvement in this regard, please contact :ref:`user_support` or submit an `issue on Github <https://github.com/xwiki-labs/cryptpad/issues/new/choose>`_.
+CryptPad is engineered to work as well as possible on small screens. Depending on your device performance it should be possible to use CryptPad on mobile. Work to make CryptPad more responsive was undertaken in 2020, if you notice areas that need improvement in this regard, please contact :ref:`user_support` or submit an `issue on Github <https://github.com/cryptpad/cryptpad/issues/new/choose>`_.
 
 Are you planning to make an app?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/_themes/theme/footer.html
+++ b/_themes/theme/footer.html
@@ -45,7 +45,7 @@
   {%- if show_sphinx %}
   {% trans %}Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a modified <a href="https://github.com/rtfd/sphinx_rtd_theme">RTD theme</a>.<br/>
   <a href="https://cryptpad.fr" title="CryptPad flagship instance">CryptPad flagship instance</a> |
-  <a href="https://github.com/xwiki-labs/cryptpad-documentation" title="The Github repository">Github repository for this documentation.</a>
+  <a href="https://github.com/cryptpad/cryptpad-documentation" title="The Github repository">Github repository for this documentation.</a>
   {% endtrans %}.
   {%- endif %}
 

--- a/admin_guide/admin_panel.rst
+++ b/admin_guide/admin_panel.rst
@@ -184,7 +184,7 @@ List my instance in public directories
 In addition to this setting being enabled, the following criteria are required in order to have an instance listed:
 
 - All :ref:`diagnostic tests <admin_checkup>` must pass
-- The version of CryptPad must be up to date within 90 days of `the latest release <https://github.com/xwiki-labs/cryptpad/releases>`_
+- The version of CryptPad must be up to date within 90 days of `the latest release <https://github.com/cryptpad/cryptpad/releases>`_
 - Instance information must be provided in the :ref:`General tab <admin_instance_info>`
 - :ref:`admin_telemetry_optout` must be enabled
 - Absence of analytics and third-party trackers
@@ -194,7 +194,7 @@ In addition to this setting being enabled, the following criteria are required i
 
 .. note::
 
-   The `list of public instances <https://cryptpad.org/instances/>`_ is considered an extension of the CryptPad community. As such, the development team reserves the right to remove instances from the list if their administrators or the groups they represent are in breach of the `Code of Conduct <https://github.com/xwiki-labs/cryptpad/blob/main/CODE_OF_CONDUCT.md>`_ or for any other reason at their own discretion.
+   The `list of public instances <https://cryptpad.org/instances/>`_ is considered an extension of the CryptPad community. As such, the development team reserves the right to remove instances from the list if their administrators or the groups they represent are in breach of the `Code of Conduct <https://github.com/cryptpad/cryptpad/blob/main/CODE_OF_CONDUCT.md>`_ or for any other reason at their own discretion.
 
 .. _admin_consent_contact:
 

--- a/admin_guide/customization.rst
+++ b/admin_guide/customization.rst
@@ -104,7 +104,7 @@ Translations
 
 To customize the text of the CryptPad interface in a given language, copy ``customize.dist/translations/messages.xx.js`` to ``customize/translations/messages.xx.js`` where ``xx`` is the locale of the language (use ``messages.js`` to customize English).
 
-In this file, modify the default text using the "Messages" object as follows: ``Messages.key = "Text";``. For all the keys and their associated text please see `www/common/translations/messages.json <https://github.com/xwiki-labs/cryptpad/blob/main/www/common/translations/messages.json>`__ or any of the ``messages.xx.json`` in the same directory for the translated text.
+In this file, modify the default text using the "Messages" object as follows: ``Messages.key = "Text";``. For all the keys and their associated text please see `www/common/translations/messages.json <https://github.com/cryptpad/cryptpad/blob/main/www/common/translations/messages.json>`__ or any of the ``messages.xx.json`` in the same directory for the translated text.
 
 For example, to customize the text about the instance on the home page, the following could be pasted in ``customize/translations/messages.js`` and the text changed to describe the instance.
 

--- a/admin_guide/installation.rst
+++ b/admin_guide/installation.rst
@@ -56,7 +56,7 @@ Clone the CryptPad repository
 
 .. code:: bash
 
-   git clone https://github.com/xwiki-labs/cryptpad.git cryptpad
+   git clone https://github.com/cryptpad/cryptpad.git cryptpad
 
 Switch to the latest published tag
 
@@ -104,7 +104,7 @@ In production you may want to run CryptPad as a daemon that restarts automatical
 Systemd
 ^^^^^^^
 
-To run CryptPad as a `systemd <https://www.freedesktop.org/software/systemd/man/systemd.service.html>`__ service, please follow the example `cryptpad.service <https://github.com/xwiki-labs/cryptpad/blob/main/docs/cryptpad.service>`__ file.
+To run CryptPad as a `systemd <https://www.freedesktop.org/software/systemd/man/systemd.service.html>`__ service, please follow the example `cryptpad.service <https://github.com/cryptpad/cryptpad/blob/main/docs/cryptpad.service>`__ file.
 
 #.  Save the example as ``cryptpad.service`` in ``/etc/systemd/system/``
 #.  Make necessary adjustments (e.g. user name, path, nodejs version)
@@ -115,7 +115,7 @@ Other ways of daemonizing nodejs applications include for example `foreverjs <ht
 FreeBSD
 ^^^^^^^
 
-To run CryptPad as a `rc.d <https://man.freebsd.org/cgi/man.cgi?query=rc.d&sektion=8&n=1>`__ unit, please follow the example `rc.d-cryptpad <https://github.com/xwiki-labs/cryptpad/blob/main/docs/rc.d-cryptpad>`__ file.
+To run CryptPad as a `rc.d <https://man.freebsd.org/cgi/man.cgi?query=rc.d&sektion=8&n=1>`__ unit, please follow the example `rc.d-cryptpad <https://github.com/cryptpad/cryptpad/blob/main/docs/rc.d-cryptpad>`__ file.
 
 #. Save the example as ``cryptpad`` in ``/usr/local/etc/rc.d/``
 #. Make necessary adjustments (e.g. user name, path)
@@ -133,12 +133,12 @@ You need two domains to take full advantage of CryptPad’s security features.
 
 The intent of this system is to limit the risk of Cross-Site Scripting (XSS) vulnerabilities allowing attackers to leak user data. Sensitive computation (like the processing of cryptographic keys) is handled on the main domain, while the user-interface is implemented on the sandbox domain.
 
-The `example Nginx configuration <https://github.com/xwiki-labs/cryptpad/blob/main/docs/example.nginx.conf>`__ file includes the relevant headers to enable the sandboxing system, however, you must configure your instance correctly for it to be effective. You will need:
+The `example Nginx configuration <https://github.com/cryptpad/cryptpad/blob/main/docs/example.nginx.conf>`__ file includes the relevant headers to enable the sandboxing system, however, you must configure your instance correctly for it to be effective. You will need:
 
 1. two domains or subdomains
 2. to include both domains in ``cryptpad/config/config.js`` as described in :ref:`admin_cryptpad_config`
 3. to generate one SSL certificate that covers both domains. The development team uses `acme.sh <https://acme.sh/>`__ and this is reflected in the example config.
-4. to correctly assign both domains and certificates to the relevant variables in the `example Nginx configuration <https://github.com/xwiki-labs/cryptpad/blob/main/docs/example.nginx.conf>`__
+4. to correctly assign both domains and certificates to the relevant variables in the `example Nginx configuration <https://github.com/cryptpad/cryptpad/blob/main/docs/example.nginx.conf>`__
 
 .. warning::
 
@@ -165,7 +165,7 @@ Note that the version of Nginx distributed by your operating system may not supp
 
 To configure Nginx for CryptPad:
 
-1. Copy the `CryptPad example Nginx config file <https://github.com/xwiki-labs/cryptpad/blob/main/docs/example.nginx.conf>`__ so that it is used/imported by the main Nginx config, for example by placing it in ``/etc/nginx/conf.d/cryptpad.conf``.
+1. Copy the `CryptPad example Nginx config file <https://github.com/cryptpad/cryptpad/blob/main/docs/example.nginx.conf>`__ so that it is used/imported by the main Nginx config, for example by placing it in ``/etc/nginx/conf.d/cryptpad.conf``.
 2. Edit the configuration file with the correct domains and paths to certificates.
 3. Run ``openssl dhparam -out /etc/nginx/dhparam.pem 4096`` if you haven’t done so already on the host machine.
 
@@ -273,4 +273,4 @@ The development team is available to provide paid support contracts (see our `or
 
 We recommend you to go over our `forum <https://forum.cryptpad.org>`_ and or `admins Matrix channel <https://matrix.to/#/#cryptpad-admins:matrix.xwiki.com>`_.
 
-Note that community support is provided by volunteers, please be aware of what you are asking of them and respect `our Code of Conduct <https://github.com/xwiki-labs/cryptpad/blob/main/CODE_OF_CONDUCT.md>`_ at all time.
+Note that community support is provided by volunteers, please be aware of what you are asking of them and respect `our Code of Conduct <https://github.com/cryptpad/cryptpad/blob/main/CODE_OF_CONDUCT.md>`_ at all time.

--- a/dev_guide/contribute.rst
+++ b/dev_guide/contribute.rst
@@ -16,7 +16,7 @@ The CryptPad source code is freely available under the `AGPLv3 <https://www.gnu.
 Git
 ~~~
 
-The source code is `published on GitHub <https://github.com/xwiki-labs/cryptpad>`_.
+The source code is `published on GitHub <https://github.com/cryptpad/cryptpad>`_.
 
 Pull requests
 ^^^^^^^^^^^^^

--- a/dev_guide/setup.rst
+++ b/dev_guide/setup.rst
@@ -23,7 +23,7 @@ Installation
 
 The source code can be found on `GitHub <https://github.com>`__. You must have an account on this platform in order to contribute.
 
--  Fork the code: https://github.com/xwiki-labs/cryptpad.git
+-  Fork the code: https://github.com/cryptpad/cryptpad.git
 -  Clone the fork on your system in the desired directory
 
    -  `git clone https://github.com/{YOUR_USER_NAME}/cryptpad.git`
@@ -48,7 +48,7 @@ Once everything is installed, you can configure some values before starting the 
    cd $cryptpath/config
    cp config.example.js config.js
 
--  The `example configuration file <https://github.com/xwiki-labs/cryptpad/blob/main/config/config.example.js>`__ lists the configurable values and how to use them.
+-  The `example configuration file <https://github.com/cryptpad/cryptpad/blob/main/config/config.example.js>`__ lists the configurable values and how to use them.
 -  For a development instance, the important elements are:
 
    -  ``httpUnsafeOrigin``: if you want to use the development server and the test client on different systems, you have to modify this value to use the network address of the server (example: 'http://192.168.0.10:3000').

--- a/how_to_contribute.rst
+++ b/how_to_contribute.rst
@@ -40,12 +40,12 @@ There are two ways to report bugs or issues:
 
 - Cryptpad's built in :ref:`support ticket system <user_support>` where you can message instance administrators. These messages are encrypted like everything else on CryptPad.
 
--  `Github issue tracker <https://github.com/xwiki-labs/cryptpad/issues/new/choose>`__ to file the issue publicly using the bug report template. (A Github account is needed to submit issues)
+-  `Github issue tracker <https://github.com/cryptpad/cryptpad/issues/new/choose>`__ to file the issue publicly using the bug report template. (A Github account is needed to submit issues)
 
 Contribute to the documentation
 -------------------------------
 
-If you have corrections, edits, or suggestions for this documentation, you can contribute and help improve the service for everyone. Please send your proposed changes to `the forum <https://forum.cryptpad.org/>`__ or use a `GitHub pull request <https://github.com/xwiki-labs/cryptpad-documentation>`__.
+If you have corrections, edits, or suggestions for this documentation, you can contribute and help improve the service for everyone. Please send your proposed changes to `the forum <https://forum.cryptpad.org/>`__ or use a `GitHub pull request <https://github.com/cryptpad/cryptpad-documentation>`__.
 
 
 .. _contribute_translation:
@@ -55,7 +55,7 @@ Translate CryptPad
 
 The CryptPad team translates the software in English and French, with many more languages provided by the community. Translating CryptPad—and/or keeping translations up to date as the platform develops—is a much needed effort to make it available to as many people as possible.
 
-To translate CryptPad itself please see the `Translation guide <https://github.com/xwiki-labs/cryptpad/blob/main/customize.dist/translations/README.md>`__.
+To translate CryptPad itself please see the `Translation guide <https://github.com/cryptpad/cryptpad/blob/main/customize.dist/translations/README.md>`__.
 
 To translate this documentation please visit the project on `Weblate <https://weblate.cryptpad.fr/projects/user-guide/>`__. To start translating a new language, please `get in touch with the development team <https://cryptpad.fr/contact.html>`__.
 
@@ -69,9 +69,9 @@ Current progression on translated languages:
 Contribute to the code
 ----------------------
 
-CryptPad is written in JavaScript and we accept pull requests on `Github <https://github.com/xwiki-labs/cryptpad>`__. Note that the security layer is separated from the application layer, so it is possible to contribute to CryptPad without skills in cryptography. Contributions include, by order of difficulty:
+CryptPad is written in JavaScript and we accept pull requests on `Github <https://github.com/cryptpad/cryptpad>`__. Note that the security layer is separated from the application layer, so it is possible to contribute to CryptPad without skills in cryptography. Contributions include, by order of difficulty:
 
-- Fixing a bug from the `issue tracker <https://github.com/xwiki-labs/cryptpad/issues>`__.
+- Fixing a bug from the `issue tracker <https://github.com/cryptpad/cryptpad/issues>`__.
 - Adding a new feature.
 - Building a new application or integrating an existing one to CryptPad's encrypted real-time collaboration.
 


### PR DESCRIPTION
Proposal to remove every occurrence mentioning the old GitHub organization.