### PR TITLE
update installation/setup to the official NodeJs LTS release channel

### DIFF
--- a/admin_guide/installation.rst
+++ b/admin_guide/installation.rst
@@ -37,9 +37,9 @@ Before starting the installation, ensure the following software is installed:
 
 -  GIT
 
--  nodejs (we use node v16.14.2)
+-  nodejs (we use the official NodeJs LTS release)
 
-   -  Using `NVM <https://github.com/nvm-sh/nvm#installing-and-updating>`__ is recommended
+   -  Using `nodesource <https://github.com/nodesource/distributions#using-debian-as-root-4>`__ is recommended
 
 -  npm
 -  bower

--- a/dev_guide/setup.rst
+++ b/dev_guide/setup.rst
@@ -9,10 +9,10 @@ Prerequisites
 Please make sure that the following tools are installed on your system before installing CryptPad:
 
 -  GIT
--  nodejs (we use node v16.14.2)
+-  nodejs (we use the official NodeJs LTS release)
 
-   -  Using `NVM <https://github.com/nvm-sh/nvm#installing-and-updating>`__ is recommended
-
+   -  Using `nodesource <https://github.com/nodesource/distributions#using-debian-as-root-4>`__ is recommended
+   
 -  npm
 -  bower
 


### PR DESCRIPTION
Here is a proposal to switch from the not-very-easy/tedious NodeJs NVM recommended installation to the official APT repositories.

Benefits:

- Spend less time worrying if our docs are up-to-date, see https://github.com/cryptpad/cryptpad/pull/1057#issuecomment-1594563673.
- Give a clear information that we aim for compatibility with [NodeJs Active LTS](https://nodejs.dev/en/about/releases/).
- Easier installation process for administrators thanks to the APT repository
  - Likely less issues/complaints about stuff not working
  - Get updates at the same time as the whole operating system
  
Cons:
- Not sure any?

Do you have an opinion @cryptpad/maintainers?