### PR TITLE
Update installation.rst: Make ndejs/npm installation more precise

### DIFF
--- a/admin_guide/installation.rst
+++ b/admin_guide/installation.rst
@@ -37,11 +37,9 @@ Before starting the installation, ensure the following software is installed:
 
 -  GIT
 
--  Nodejs (we use the official NodeJs LTS release)
+-  Nodejs with NPM included (we use the official NodeJs LTS release)
 
    -  Using `nodesource <https://github.com/nodesource/distributions#using-debian-as-root-4>`__ is recommended
-
--  NPM
 
 
 - Docker engine (if using Docker, see :ref:`Install with Docker <admin_docker_install>`)


### PR DESCRIPTION
Since npm is already included in the nodejs installation, this is should be more precise in the documentation. If you install nodejs on Debian 11 and afterwards npm, npm installation will fail with dependency errors.