### PR TITLE
Uniformize notation for `Click`

### DIFF
--- a/user_guide/apps/whiteboard.rst
+++ b/user_guide/apps/whiteboard.rst
@@ -36,7 +36,7 @@ To delete everything on the canvas:
 
 The width and opacity of line are set in the drawing toolbar. The preview to the right shows the size and opacity of the paintbrush.
 
-Color is selected in the palette in the drawing toolbar. To change a color ``Double click`` on it and select a new one using the color-picker.
+Color is selected in the palette in the drawing toolbar. To change a color double click on it and select a new one using the color-picker.
 
 |arrows| Select mode
 --------------------

--- a/user_guide/collaboration.rst
+++ b/user_guide/collaboration.rst
@@ -69,7 +69,7 @@ You can create recurring events, repeat:
       - On a specific date
       - After X times
 
-To edit events, drag them to the new date/time or ``Click`` to open the detailed edit view.
+To edit events, drag them to the new date/time or click to open the detailed edit view.
 
 Toolbar
 ~~~~~~~
@@ -141,7 +141,7 @@ All contacts are listed at the left of the window. For each contact:
 Chat with contacts
 ~~~~~~~~~~~~~~~~~~
 
-On the Contacts page, ``Click`` on a contact in the list to open the chat with them in the main window.
+On the Contacts page, click on a contact in the list to open the chat with them in the main window.
 
 Write messages in the field at the bottom and send them with |paper-plane| or ``Enter``.
 


### PR DESCRIPTION
- Should be “click” when used as a verb
- Should be “`Click`” when used as a directive for an action