### PR TITLE
Proofreading of the documentation

### DIFF
--- a/_themes/theme/static/css/theme.css
+++ b/_themes/theme/static/css/theme.css
@@ -2511,8 +2511,12 @@ legend {
 p {
     line-height: 24px;
     margin: 0;
-    font-size: 16px;
+    font-size: 1.1em;
     margin-bottom: 24px;
+}
+
+.wy-nav-content a {
+    font-size: 100%;
 }
 
 h1 {
@@ -3177,6 +3181,7 @@ select#language-selector-container option {
     margin-left: 300px;
     background: #fcfcfc;
     min-height: 100%;
+    max-width: 100ch;
 }
 
 .wy-nav-content {

--- a/admin_guide/admin_panel.rst
+++ b/admin_guide/admin_panel.rst
@@ -112,7 +112,7 @@ The login block is what allows an account to log in to CryptPad with the combina
 2FA Recovery
 ~~~~~~~~~~~~
 
-Users can copy recovery data on the 2FA recovery page /recovery/ and email it to the instance administrators. Paste recovery data below to disable 2FA for an account
+Users can copy recovery data on the 2FA recovery page https://your-instance.com/recovery/ in the "*Forgot recovery code*" section and email it to the instance administrators. Paste recovery data below to disable 2FA for an account
 
 Statistics
 ----------

--- a/admin_guide/installation.rst
+++ b/admin_guide/installation.rst
@@ -35,7 +35,7 @@ Software
 
 Before starting the installation, ensure the following software is installed:
 
--  GIT
+-  Git
 
 -  Nodejs with NPM included (we use the official NodeJs LTS release)
 

--- a/conf.py
+++ b/conf.py
@@ -166,7 +166,7 @@ class Cptools(Directive):
         node = emphasis(**options)
         return [node]
 
-cptools_icons = ['destroy', 'add-bottom', 'add-top', 'folder-upload', 'folder-no-color', 'slide', 'shared-folder', 'poll', 'file-upload', 'whiteboard', 'todo', 'pad', 'folder-open', 'kanban', 'folder', 'shared-folder-open', 'code', 'template', 'new-template', 'palette', 'form-poll', 'form-poll-maybe', 'form-list-check', 'form-grid-check', 'form-grid-radio', 'form-list-radio', 'form-page-break', 'form-paragraph', 'form-text', 'form-list-ordered', 'form-conditional']
+cptools_icons = ['destroy', 'add-bottom', 'add-top', 'folder-upload', 'folder-no-color', 'slide', 'shared-folder', 'poll', 'file-upload', 'whiteboard', 'todo', 'pad', 'folder-open', 'kanban', 'folder', 'shared-folder-open', 'code', 'template', 'new-template', 'palette', 'form-poll', 'form-poll-maybe', 'form-list-check', 'form-grid-check', 'form-grid-radio', 'form-list-radio', 'form-page-break', 'form-paragraph', 'form-text', 'form-list-ordered', 'form-conditional', 'richtext']
 
 prolog = '\n'.join(['.. |cptools %s| cptools:: %s' % (icon, icon) for icon in cptools_icons])
 prolog += '\n'

--- a/dev_guide/client/architecture.rst
+++ b/dev_guide/client/architecture.rst
@@ -29,7 +29,7 @@ The worker is the unique WebSocket link with the server for all CryptPad tabs. `
 -  Gain in resources on the server (only one connection with each client)
 -  The **workers** represent code executed in a different thread from the main tab, allowing heavier calculations to be performed without slowing down the page.
 
-Please note that not all browsers have implemented SharedWorkers. They are only available on Firefox and Chromium-based browsers. Internet Explorer as well as older versions of Edge do not support them but the newer versions of Edge are based on Chromium and allow it. Apple refuses to develop them for Safari.
+Please note that not all browsers have implemented SharedWorkers. They are only available on Firefox and Chromium-based browsers. Internet Explorer as well as older versions of Edge do not support them but the newer versions of Edge are based on Chromium and allow it. Safari only supports them for recent versions as well (version 16 or newer).
 
 For these obsolete browsers, the system automatically switches to classic Web Workers, i.e. 1 worker per tab. This still allows the use of a separate thread for heavier calculations, but it strongly slows down the loading of tabs when the user account contains a lot of data. Finally, if the WebWorkers have been disabled in the browser, a last-resort system is in place to perform the work of the worker in the main tab at the **outer** level. This has no impact on the functioning of the code but does not benefit from the advantages of the workers.
 

--- a/dev_guide/client/architecture.rst
+++ b/dev_guide/client/architecture.rst
@@ -23,7 +23,7 @@ Worker
 Workflow
 ~~~~~~~~
 
-The worker is the unique WebSocket link with the server for all CryptPad tabs. [SharedWorker](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker) technology allows a single [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker) to be shared between all the tabs opened on the same origin, with many advantages:
+The worker is the unique WebSocket link with the server for all CryptPad tabs. `SharedWorker <https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker>`_ technology allows a single `Web Worker <https://developer.mozilla.org/en-US/docs/Web/API/Worker>`_ to be shared between all the tabs opened on the same origin, with many advantages:
 
 -  Gain in resources on the client (memory, CPU and network saved by avoiding the repetition of tasks)
 -  Gain in resources on the server (only one connection with each client)
@@ -53,9 +53,13 @@ Once the connector is loaded with the desired technology, the exact same code go
 Access to content stored in the server database is done with commands to the worker. This content represents:
 
 -  User account data (name, personal keys, access to the different modules)
+
    -  Drive, shared folders, contacts, team access keys, profile, settings, etc.
+
 -  Team data
+
    -  Drive, shared folders, members, metadata (avatar and team name)
+
 -  Access to documents for each CryptPad tab opened in the browser
 
 Debugging

--- a/dev_guide/client/inner.rst
+++ b/dev_guide/client/inner.rst
@@ -56,6 +56,6 @@ This module provides tools to display elements with pre-existing content, someti
 -  Display the pad creation screen
 -  Create action buttons for the toolbar with the appropriate style
 -  Create a Markdown toolbar (for code, slide, poll and profile applications)
--  Create a "Help / Getting started..." menu for the current application
+-  Create a "|question| Help / Getting started..." menu for the current application
 -  Create a drop-down menu to change the interface language
 -  Many other tools ...

--- a/dev_guide/database.rst
+++ b/dev_guide/database.rst
@@ -11,9 +11,10 @@ Key points
 * Each CryptPad document has information stored on the server in a location determined by a channel id
 * The content of each document is encrypted using the encryption key, so that the server cannot read it
 * Clients send the channel id to the server to:
-  * get the latest information about a document
-  * subscribe to ongoing updates while they are connected
-  * modify the contents of the document
+
+    * get the latest information about a document
+    * subscribe to ongoing updates while they are connected
+    * modify the contents of the document
 * each *channel* is stored within its own file on the server
 * each change to the document is encoded on a single line of that file
 

--- a/dev_guide/setup.rst
+++ b/dev_guide/setup.rst
@@ -8,7 +8,7 @@ Prerequisites
 
 Please make sure that the following tools are installed on your system before installing CryptPad:
 
--  GIT
+-  Git
 -  Nodejs (we use the official NodeJs LTS release)
 
    -  Using `nodesource <https://github.com/nodesource/distributions#using-debian-as-root-4>`__ for Linux

--- a/user_guide/apps/form.rst
+++ b/user_guide/apps/form.rst
@@ -67,9 +67,9 @@ Question types
 |cptools form-text| Text
 ++++++++++++++++++++++++
 
-Response: one line of text
+**Response**: one line of text
 
-Options:
+**Options**:
 
 - Text type: text, number, link or email
 
@@ -80,9 +80,9 @@ Options:
 |cptools form-paragraph| Paragraph
 ++++++++++++++++++++++++++++++++++
 
-Response: multiple lines of text
+**Response**: multiple lines of text
 
-Options:
+**Options**:
 
 - Maximum characters: limit (defaults to 1000)
 
@@ -91,9 +91,9 @@ Options:
 |cptools form-list-radio| Choice
 ++++++++++++++++++++++++++++++++
 
-Response: one choice from the list
+**Response**: one choice from the list
 
-Options:
+**Options**:
 
 - |plus| **Add option** button
 - Grab the |ellipsis-v| |ellipsis-v| handle and drag to re-order options
@@ -102,9 +102,9 @@ Options:
 |cptools form-grid-radio| Choice Grid
 +++++++++++++++++++++++++++++++++++++
 
-Response: one option choice per item
+**Response**: one option choice per item
 
-Options:
+**Options**:
 
 - |plus| **Add option** and |plus| **Add item** buttons
 - Grab the |ellipsis-v| |ellipsis-v| handle and drag to re-order items and options
@@ -113,16 +113,16 @@ Options:
 |calendar| Date
 ++++++++++++++++++++++++
 
-Response: pick a date and time
+**Response**: pick a date and time
 
 .. _form_Q_checkbox:
 
 |cptools form-list-check| Checkbox
 ++++++++++++++++++++++++++++++++++
 
-Response: multiple choices from the list
+**Response**: multiple choices from the list
 
-Options:
+**Options**:
 
 - Maximum selectable options
 - |plus| **Add option** button
@@ -132,9 +132,9 @@ Options:
 |cptools form-grid-check| Checkbox Grid
 +++++++++++++++++++++++++++++++++++++++
 
-Response: multiple choices for each item
+**Response**: multiple choices for each item
 
-Options:
+**Options**:
 
 - Maximum selectable options (per item)
 - |plus| **Add option** and |plus| **Add item** buttons
@@ -144,24 +144,24 @@ Options:
 |cptools form-list-ordered| Ordered List
 ++++++++++++++++++++++++++++++++++++++++
 
-Response: order of preference for the listed options
+**Response**: order of preference for the listed options
 
-Options:
+**Options**:
 
 - |plus| **Add option** button
 - Grab the |ellipsis-v| |ellipsis-v| handle and drag to re-order options
 - Delete an option with |times|
 
-Condorcet:
+**Condorcet**:
 
 Since v5.3 responses can show the results with the `Condorcet method <https://en.wikipedia.org/wiki/Condorcet_method>`_. You can select Schulze or Ranked Pairs to display the winner. The details will also show the number of matches won by each candidates.
 
 |cptools form-poll| Poll
 ++++++++++++++++++++++++
 
-Response: |check| Yes, |times| No, or |cptools form-poll-maybe| Acceptable for each of the proposed options
+**Response**: |check| Yes, |times| No, or |cptools form-poll-maybe| Acceptable for each of the proposed options
 
-Option types:
+**Option types**:
 
 - Text
 

--- a/user_guide/apps/richtext.rst
+++ b/user_guide/apps/richtext.rst
@@ -53,10 +53,10 @@ Import/Export
 -------------
 
 | |file-o| **File** > |upload| **Import**
-| Supported formats: ``.html``.
+| Supported formats: ``.html``, ``.md``.
 
 | |file-o| **File** > |download| **Export**
-| Supported formats: ``.html``, ``.doc``.
+| Supported formats: ``.html``, ``.doc``, ``.md``.
 
 To print or export a PDF:
 

--- a/user_guide/collaboration.rst
+++ b/user_guide/collaboration.rst
@@ -43,6 +43,8 @@ On another user’s profile page:
 -  |bell-slash| **Mute**: Blocks notifications and messages from this user. They will not know that they have been muted.
 -  |key| **Copy public key**: Copies the key used by instance administrators and on instances that offer subscriptions.
 
+.. _calendar:
+
 Calendar
 --------
 

--- a/user_guide/security.rst
+++ b/user_guide/security.rst
@@ -85,7 +85,7 @@ In some cases (loss or theft of a device, forgotten to log out of a session on a
 
 * User menu (avatar at the top-right) > |gear| **Settings** > |lock| **Confidentiality** > **LOG OUT**.
 
-This option logs out all sessions **except** the one from which it is actiaved.
+This option logs out all sessions **except** the one from which it is activated.
 
 * User menu (avatar at the top-right) > |plug| **Log out everywhere**.
 

--- a/user_guide/user_account.rst
+++ b/user_guide/user_account.rst
@@ -21,6 +21,7 @@ No personal information is necessary to use CryptPad without registering. Howeve
 -  Sharing and collaborating on documents.
 -  Storage limited to 3 months of inactivity (counted per document).
 -  File storage unavailable for images/videos/PDF/etc…
+-  Limited access to :ref:`calendars <calendar>` (link-shared calendars only).
 
 Logged in user
 ~~~~~~~~~~~~~~
@@ -35,6 +36,7 @@ Registering an account does not require any personal information, only a usernam
 -  Organisation of documents in :ref:`folders <folders>`, :ref:`shared folders <shared_folders>`, or with :ref:`tags <tags>` and :ref:`templates <templates>`.
 -  Creation of :ref:`teams <teams>`.
 -  Customisation of the :ref:`profile <profile>` page and a list of :ref:`contacts <contacts>` to :ref:`share documents <share>` and :ref:`chat <chat_contacts>` with. Notifications for interactions between contacts.
+-  Creation and management of :ref:`calendars <calendar>`.
 
 Premium user
 ~~~~~~~~~~~~

--- a/user_guide/user_account.rst
+++ b/user_guide/user_account.rst
@@ -228,7 +228,7 @@ On the notifications panel page:
 
    -  |bars| All.
    -  |user| Contact Requests.
-   -  |cptools pad| Shared with me.
+   -  |cptools richtext| Shared with me.
    -  |archive| History.
 
 -  |trash|: Delete notifications.


### PR DESCRIPTION
Hi,

This pull request compiles a full proofreading of the documentation that does the following changes:
1. Fix obvious typos;
2. Fix ill-formatted RST (markdown links, lists that were merged);
3. Fix outdated information (for instance shared workers not implemented in Safari);
4. Fix inconsistencies in some paths;
5. Fix missing icons or wrong icons;
6. Fix a style issue in the Form application page;
7. Reduce the `max-width` of the content (to 100ch, 65ch seems too narrow for some reasons) for readability purpose, as well as increase the default font-size using `em` instead of pixels.

Note that to preserve the work done by the translation community, the changes have been kept to minimum.